### PR TITLE
Move some regexp to globals, to benefit from compiled regexp

### DIFF
--- a/scenario/regExpression.go
+++ b/scenario/regExpression.go
@@ -5,26 +5,25 @@ import (
 	"regexp"
 )
 
+var (
+	matchStringWithNoSpace = regexp.MustCompile(`^[A-z]+$`)
+	matchStringWithSpace   = regexp.MustCompile(`^[A-z' ']+$`)
+	matchNumbers           = regexp.MustCompile(`^\d+$`)
+	matchEmail             = regexp.MustCompile(`@`)
+)
+
 // IsStringNoSpace returns true if s contains only letters without a space
-func IsStringNoSpace(s string) (bool, error) {
-	isValid, err := regexp.MatchString(`^[A-z]+$`, s)
-	if err != nil {
-		return false, fmt.Errorf("An error occured: %s ", err)
-	}
-	return isValid, nil
+func IsStringNoSpace(s string) bool {
+	return matchStringWithNoSpace.MatchString(s)
 }
 
 // IsStringSpace returns true if s contains only letters with a space
-func IsStringSpace(s string) (bool, error) {
-	isValid, err := regexp.MatchString(`^[A-z' ']+$`, s)
-	if err != nil {
-		return false, fmt.Errorf("An error occured: %s ", err)
-	}
-	return isValid, nil
+func IsStringSpace(s string) bool {
+	return matchStringWithNoSpace.MatchString(s)
 }
 
-// IsStringLength returns true if s contains only letters and the length specified matches
-func IsStringLength(s string, length int) (bool, error) {
+// IsAlphaNumericWithLength returns true if s contains only letters and the length specified matches
+func IsAlphaNumericWithLength(s string, length int) (bool, error) {
 	pattern := fmt.Sprintf(`^[A-z]{%d}$`, length)
 	isValid, err := regexp.MatchString(pattern, s)
 	if err != nil {
@@ -33,17 +32,13 @@ func IsStringLength(s string, length int) (bool, error) {
 	return isValid, nil
 }
 
-// IsNumberOnly returns true if s contains only number
-func IsNumber(s string) (bool, error) {
-	isValid, err := regexp.MatchString(`^\d+$`, s)
-	if err != nil {
-		return false, fmt.Errorf("An error occured: %s ", err)
-	}
-	return isValid, nil
+// IsNumeric returns true if s contains only number
+func IsNumeric(s string) bool {
+	return matchNumbers.MatchString(s)
 }
 
-// IsNumberLength returns true if s contains only number
-func IsNumberLength(s string, length int) (bool, error) {
+// IsNumericWithLength returns true if s contains only number
+func IsNumericWithLength(s string, length int) (bool, error) {
 	pattern := fmt.Sprintf(`^\d{%d}$`, length)
 	isValid, err := regexp.MatchString(pattern, s)
 	if err != nil {
@@ -53,10 +48,6 @@ func IsNumberLength(s string, length int) (bool, error) {
 }
 
 // IsEmail returns true if s is a valid email
-func IsEmail(s string) (bool, error) {
-	isValid, err := regexp.MatchString(`@`, s)
-	if err != nil {
-		return false, fmt.Errorf("An error occured: %s ", err)
-	}
-	return isValid, nil
+func IsEmail(s string) bool {
+	return matchEmail.MatchString(s)
 }


### PR DESCRIPTION
Regex is usually expensive to compile, so moving it to a global, means that it is compiled at package import time, and reused everytime it is called. 